### PR TITLE
feat(hero): support image or video background with required cover

### DIFF
--- a/src/app/[locale]/(marketing)/page.tsx
+++ b/src/app/[locale]/(marketing)/page.tsx
@@ -22,13 +22,19 @@ export default async function Index() {
   const stores = await getAllStores();
   const contact = settings?.contactEntaopronto;
   const socials = settings?.socialMediaEntaopronto;
+  const hero = settings?.hero;
 
   return (
     <>
       <Hero.Primary
-        title="Conecte-se sua marca ao Shopping EntãoPronto"
-        // videoUrl="https://videos.openai.com/vg-assets/assets%2Ftask_01jnc96zqsfhpbm0q8w0pqtx1f%2Ftask_01jnc96zqsfhpbm0q8w0pqtx1f_genid_ef1d0b10-0133-422b-a09c-182e2f3328e5_25_03_02_20_37_508349%2Fvideos%2F00000_93576231%2Fmd.mp4?st=2025-07-14T13%3A40%3A50Z&se=2025-07-20T14%3A40%3A50Z&sks=b&skt=2025-07-14T13%3A40%3A50Z&ske=2025-07-20T14%3A40%3A50Z&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skoid=aa5ddad1-c91a-4f0a-9aca-e20682cc8969&skv=2019-02-02&sv=2018-11-09&sr=b&sp=r&spr=https%2Chttp&sig=pukayKWl0oGqY88O2jpXBFeQY9kdKBg3D%2FBzJTjgBaE%3D&az=oaivgprodscus"
-        imageUrl="/assets/images/bg_mall.webp"
+        title={hero?.title || 'Conecte-se sua marca ao Shopping EntãoPronto'}
+        media={{
+          type: hero?.mediaType,
+          image: hero?.image,
+          videoMp4: hero?.videoMp4,
+          videoWebm: hero?.videoWebm,
+          poster: hero?.poster,
+        }}
         brandCategories={categories.map(category => ({
           label: category.title,
           value: category.slug,

--- a/src/components/sections/Hero/HeroPrimary.tsx
+++ b/src/components/sections/Hero/HeroPrimary.tsx
@@ -3,55 +3,101 @@ import type { BrandCategoryOption } from '@/components/BrandRegistrationModal';
 import { motion } from 'motion/react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/atoms/Button';
 import { BrandRegistrationModal } from '@/components/BrandRegistrationModal';
 import Container from '@/components/Container';
 import Typography from '@/components/Typography';
 
+type HeroMedia = {
+  type?: 'image' | 'video';
+  image?: string;
+  videoMp4?: string;
+  videoWebm?: string;
+  poster?: string;
+};
+
 type Props = {
   title: string;
-  videoUrl?: string;
-  imageUrl?: string;
+  media?: HeroMedia;
   brandCategories?: BrandCategoryOption[];
   whatsappPhone?: string;
 };
 
 const EMPTY_BRAND_CATEGORIES: BrandCategoryOption[] = [];
+const FALLBACK_IMAGE = '/assets/images/bg-mall.webp';
 
 const HeroPrimary = ({
   title,
-  videoUrl = '/assets/images/test.mp4',
-  imageUrl = '/assets/images/bg-mall.webp',
+  media,
   brandCategories = EMPTY_BRAND_CATEGORIES,
   whatsappPhone,
 }: Props) => {
   const [isBrandModalOpen, setIsBrandModalOpen] = useState(false);
+  const [shouldRenderVideo, setShouldRenderVideo] = useState(false);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  const mediaType = media?.type ?? 'image';
+  const isVideo = mediaType === 'video' && Boolean(media?.videoMp4 || media?.videoWebm);
+  // For images: use the configured image. For videos: poster is the cover (required at CMS level).
+  const coverImage = isVideo ? media?.poster : media?.image ?? FALLBACK_IMAGE;
+
+  // Defer video mounting until after first paint and only when the user
+  // hasn't requested reduced motion. The poster image carries the LCP.
+  useEffect(() => {
+    if (!isVideo) {
+      return;
+    }
+
+    const prefersReducedMotion
+      = typeof window !== 'undefined'
+        && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReducedMotion) {
+      return;
+    }
+
+    const idle = (cb: () => void) => {
+      const w = window as Window & { requestIdleCallback?: (cb: () => void) => number };
+      if (typeof w.requestIdleCallback === 'function') {
+        w.requestIdleCallback(cb);
+      } else {
+        window.setTimeout(cb, 250);
+      }
+    };
+
+    idle(() => setShouldRenderVideo(true));
+  }, [isVideo]);
 
   return (
     <section className="relative isolate overflow-hidden flex items-center">
-      {/* Background media */}
-      {videoUrl && (
-        <video
-          autoPlay
-          loop
-          muted
-          playsInline
-          className="absolute inset-0 w-full h-full object-cover z-0"
-        >
-          <source src={videoUrl} type="video/mp4" />
-          Your browser does not support the video tag.
-        </video>
-      )}
-      {imageUrl && (
+      {/* Cover image — always rendered as the LCP element */}
+      {coverImage && (
         <Image
-          src={imageUrl}
+          src={coverImage}
           alt=""
           aria-hidden="true"
           fill
           priority
+          sizes="100vw"
           className="absolute inset-0 w-full h-full object-cover z-0"
         />
+      )}
+
+      {/* Background video — mounted after first paint, layered above the poster */}
+      {isVideo && shouldRenderVideo && (
+        <video
+          ref={videoRef}
+          autoPlay
+          loop
+          muted
+          playsInline
+          preload="metadata"
+          poster={media?.poster}
+          className="absolute inset-0 w-full h-full object-cover z-0"
+        >
+          {media?.videoWebm && <source src={media.videoWebm} type="video/webm" />}
+          {media?.videoMp4 && <source src={media.videoMp4} type="video/mp4" />}
+        </video>
       )}
 
       {/* Layered overlays for depth */}

--- a/src/libs/sanity/queries.ts
+++ b/src/libs/sanity/queries.ts
@@ -114,6 +114,14 @@ export const searchStoresQueryParams = (query: string) => `
 
 /* Site Settings */
 export const siteSettingsFields = `{
+  hero {
+    title,
+    mediaType,
+    "image": image.asset->url,
+    "videoMp4": videoMp4.asset->url,
+    "videoWebm": videoWebm.asset->url,
+    "poster": poster.asset->url
+  },
   aboutUs {
     description,
     "image": image.asset->url

--- a/src/libs/sanity/types.ts
+++ b/src/libs/sanity/types.ts
@@ -16,7 +16,19 @@ export type NavLinkSchema = {
   openInNewTab?: boolean;
 };
 
+export type HeroMediaType = 'image' | 'video';
+
+export type HeroSchema = {
+  title?: string;
+  mediaType?: HeroMediaType;
+  image?: string;
+  videoMp4?: string;
+  videoWebm?: string;
+  poster?: string;
+};
+
 export type SiteSettingsSchema = {
+  hero?: HeroSchema;
   aboutUs: {
     image: string;
     description: PortableTextBlock;


### PR DESCRIPTION
## Summary
- Hero on the homepage now supports either an image or a horizontal background video, driven by Sanity.
- For videos, a cover image (poster) is required at the CMS level and is rendered as the LCP element while the video loads.
- The `<video>` tag mounts after first paint (via `requestIdleCallback`), uses `preload="metadata"`, prefers WebM over MP4, and is skipped entirely when the user has `prefers-reduced-motion: reduce`.

## Changes
- New `media` prop on `HeroPrimary` replacing the old `videoUrl`/`imageUrl` pair.
- Extended Sanity query and types: `siteSettings.hero { title, mediaType, image, videoMp4, videoWebm, poster }` (sibling PR in the CMS repo).
- Homepage now reads hero data from `getSiteSettings()` with a copy fallback.

## Test plan
- [ ] Editor: pick **Imagem** in CMS → frontend renders Next/Image as background.
- [ ] Editor: pick **Vídeo**, upload MP4 + poster → poster appears instantly; video starts after first paint.
- [ ] Upload WebM as well → DevTools confirms the WebM source is used in Chromium/Firefox.
- [ ] Toggle OS-level "Reduce motion" → only the poster shows; no video network request.
- [ ] Lighthouse: LCP element is the poster image and remains under threshold.

## Related
- CMS schema PR: Agility-Creative-Solutions/sanity-shopping-entaopronto#3