### PR TITLE
fix(hero): correct fallback image filename (bg-mall → bg_mall)

### DIFF
--- a/src/components/sections/Hero/HeroPrimary.tsx
+++ b/src/components/sections/Hero/HeroPrimary.tsx
@@ -25,7 +25,7 @@ type Props = {
 };
 
 const EMPTY_BRAND_CATEGORIES: BrandCategoryOption[] = [];
-const FALLBACK_IMAGE = '/assets/images/bg-mall.webp';
+const FALLBACK_IMAGE = '/assets/images/bg_mall.webp';
 
 const HeroPrimary = ({
   title,


### PR DESCRIPTION
## Summary
- One-line follow-up to #27. The fallback in `HeroPrimary` pointed at `/assets/images/bg-mall.webp` (hyphen), but the actual file is `bg_mall.webp` (underscore).
- Production was 400ing on `_next/image?url=%2Fassets%2Fimages%2Fbg-mall.webp` whenever Sanity returned no hero data.
- This commit was authored on the original PR branch but pushed after #27 was merged, so it never made it to main.

## Test plan
- [ ] Hard-refresh production homepage with hero unfilled in Sanity → no 400 on `_next/image`.