### PR TITLE
fix(ui): hero fallback image filename + preserve navbar label casing

### DIFF
--- a/src/components/atoms/Header/Navbar.tsx
+++ b/src/components/atoms/Header/Navbar.tsx
@@ -7,7 +7,7 @@ type NavbarProps = {
 };
 
 const linkClasses = [
-  'relative inline-flex items-center gap-1.5 text-sm font-semibold uppercase tracking-wide',
+  'relative inline-flex items-center gap-1.5 text-sm font-semibold tracking-wide',
   'text-white/90 hover:text-white transition-colors duration-200',
   'after:content-[\'\'] after:absolute after:left-0 after:-bottom-1 after:h-px after:w-0',
   'after:bg-white/80 after:transition-all after:duration-300 hover:after:w-full',


### PR DESCRIPTION
## Summary
- Restore desktop navbar link casing to match the exact label from Sanity (remove forced `uppercase`).
- Correct the hero fallback image filename (`bg-mall.webp` → `bg_mall.webp`) so the cover renders when no Sanity image/video is set.

## Test plan
- [ ] Desktop navbar: labels render in the casing set in Sanity (no auto-uppercase).
- [ ] Mobile navbar: labels unchanged (already preserved casing).
- [ ] Hero without a Sanity-defined media falls back to `/assets/images/bg_mall.webp` without a 404.